### PR TITLE
Adds stack trimmed images functionality

### DIFF
--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -975,39 +975,29 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir, outside_cr
                         utils.move_crops_containing_locations(csv_path, group, (target_dir / group.name))
 
 
-def stack_trimmed_images(source_dir, postfix, output_dir=None):
+def stack_trimmed_images(source_dir, postfix="", output_dir=None):
 
     """Stack images of the same position with different capture dates and write them to tifs.
-    
-    Folowing speckle variants can be chosen
-        speckle = "speckle-test_boxcar_trimmed"
-        speckle = "speckle-test_frost_trimmed"
-        speckle = "speckle-test_gamma-map_trimmed"
-        speckle = "speckle-test_IDAN_trimmed"
-        speckle = "speckle-test_lee_trimmed"
-        speckle = "speckle-test_lee-sigma_trimmed"
-        speckle = "speckle-test_median_trimmed"
-        speckle = "speckle-test_no-speckle_trimmed"
-        speckle = "speckle-test_refined-lee_trimmed"
     
     Parameters
     ----------
     root_dir: Path
         Path of trimmed crops with various speckle variants and recording times.
-    speckle: String
-        Set desired speckle variant (e.g. "speckle-test_lee-sigma_trimmed", "speckle-test_boxcar_trimmed") 
+    postfix: String
+        Set desired postfix for selecting specific folders containing a certain string 
+        (by default is empty "" and therefore selects every folder in source_dir)
     output_dir: Path
         Path where the stacked image shall be stored (by default is equal to root_dir)
     """
 
-    root_dir = pathlib.Path(root_dir)
+    source_dir = pathlib.Path(source_dir)
     if output_dir == None:
-        output_dir = root_dir
+        output_dir = source_dir
     else:
         output_dir = pathlib.Path(output_dir)
 
-    lat_lon_set = utils.get_unique_lat_lon(root_dir, speckle)
+    lat_lon_set = utils.get_unique_lat_lon(source_dir, postfix)
 
     for position in tqdm(lat_lon_set, desc="Stacking images and writing tifs: "):
-        image_path_list = utils.get_image_path_list(root_dir, speckle, position)
-        utils.stack_trimmed_images(image_path_list, output_dir, speckle, position)
+        image_path_list = utils.get_image_path_list(source_dir, postfix, position)
+        utils.stack_trimmed_images(image_path_list, output_dir, postfix, position)

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -973,3 +973,7 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir, outside_cr
 
                     else:
                         utils.move_crops_containing_locations(csv_path, group, (target_dir / group.name))
+
+
+def stack_trimmed_images():
+    pass

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -976,17 +976,16 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir, outside_cr
 
 
 def stack_trimmed_images(source_dir, postfix="", output_dir=None):
-
     """Stack images of the same position with different capture dates and write them to tifs.
     
     Parameters
     ----------
     root_dir: Path
-        Path of trimmed crops with various speckle variants and recording times.
-    postfix: String
+        Path of trimmed crops of various recording times which shall be stacked
+    postfix: String, optional
         Set desired postfix for selecting specific folders containing a certain string 
-        (by default is empty "" and therefore selects every folder in source_dir)
-    output_dir: Path
+        (by default is empty "" and therefore selects every folder in source_dir).
+    output_dir: Path, optional
         Path where the stacked image shall be stored (by default is equal to root_dir)
     """
 
@@ -996,8 +995,8 @@ def stack_trimmed_images(source_dir, postfix="", output_dir=None):
     else:
         output_dir = pathlib.Path(output_dir)
 
-    lat_lon_set = utils.get_unique_lat_lon(source_dir, postfix)
+    lat_lon_set = utils.get_unique_lat_lon_set(source_dir, postfix)
 
     for position in tqdm(lat_lon_set, desc="Stacking images and writing tifs: "):
-        image_path_list = utils.get_image_path_list(source_dir, postfix, position)
-        utils.stack_trimmed_images(image_path_list, output_dir, postfix, position)
+        image_path_list = utils.get_image_path_list(source_dir, position, postfix)
+        utils.stack_trimmed_images(image_path_list, output_dir, position, postfix)

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -975,7 +975,8 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir, outside_cr
                         utils.move_crops_containing_locations(csv_path, group, (target_dir / group.name))
 
 
-def stack_trimmed_images(root_dir, speckle, output_dir=None):
+def stack_trimmed_images(source_dir, postfix, output_dir=None):
+
     """Stack images of the same position with different capture dates and write them to tifs.
     
     Folowing speckle variants can be chosen

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -975,5 +975,38 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir, outside_cr
                         utils.move_crops_containing_locations(csv_path, group, (target_dir / group.name))
 
 
-def stack_trimmed_images():
-    pass
+def stack_trimmed_images(root_dir, speckle, output_dir=None):
+    """Stack images of the same position with different capture dates and write them to tifs.
+    
+    Folowing speckle variants can be chosen
+        speckle = "speckle-test_boxcar_trimmed"
+        speckle = "speckle-test_frost_trimmed"
+        speckle = "speckle-test_gamma-map_trimmed"
+        speckle = "speckle-test_IDAN_trimmed"
+        speckle = "speckle-test_lee_trimmed"
+        speckle = "speckle-test_lee-sigma_trimmed"
+        speckle = "speckle-test_median_trimmed"
+        speckle = "speckle-test_no-speckle_trimmed"
+        speckle = "speckle-test_refined-lee_trimmed"
+    
+    Parameters
+    ----------
+    root_dir: Path
+        Path of trimmed crops with various speckle variants and recording times.
+    speckle: String
+        Set desired speckle variant (e.g. "speckle-test_lee-sigma_trimmed", "speckle-test_boxcar_trimmed") 
+    output_dir: Path
+        Path where the stacked image shall be stored (by default is equal to root_dir)
+    """
+
+    root_dir = pathlib.Path(root_dir)
+    if output_dir == None:
+        output_dir = root_dir
+    else:
+        output_dir = pathlib.Path(output_dir)
+
+    lat_lon_set = utils.get_unique_lat_lon(root_dir, speckle)
+
+    for position in tqdm(lat_lon_set, desc="Stacking images and writing tifs: "):
+        image_path_list = utils.get_image_path_list(root_dir, speckle, position)
+        utils.stack_trimmed_images(image_path_list, output_dir, speckle, position)

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -1839,7 +1839,8 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir):
                             break                 
 
 
-def get_unique_lat_lon(root_dir, speckle):
+def get_unique_lat_lon_set(source_dir, postfix):
+
     """Loops through every folder of the specified speckle variant in rootdir and returns 
     a set with unique latitude and longitude positions.
 

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -1837,3 +1837,117 @@ def move_crops_containing_locations(csv_path, source_dir, target_dir):
                             target_dir.mkdir(parents=True, exist_ok=True)
                             shutil.move(str(crop.absolute()), str(target_dir.absolute()))
                             break                 
+
+
+def get_unique_lat_lon(root_dir, speckle):
+    """Loops through every folder of the specified speckle variant in rootdir and returns 
+    a set with unique latitude and longitude positions.
+
+    Parameters
+    ----------
+    root_dir: Path
+        Path of trimmed crops with various speckle variants and recording times.
+    speckle: String
+        Set desired speckle variant (options available in geocropper.stack_trimmed_images) 
+    """
+    
+    # Set is an unordered list which allows no duplicated entries
+    lat_lon_set = set()
+
+    print(f"Reading unique positions for {speckle}...")
+
+    for folder in root_dir.glob(f"*{speckle}*"):
+        if folder.is_dir() and folder.name.split("_")[0] != "stacked":
+            for crop in folder.glob("*"):
+                if crop.is_dir() and crop.name != "0_combined-preview":
+                    lat_lon_set.add(crop.name.split("_")[1] + "_" + crop.name.split("_")[2])
+
+    return lat_lon_set
+
+
+def get_image_path_list(root_dir, speckle, position):
+    """Find one or more images of a specified position in the root directory and returns a list containing the 
+    paths of these images.
+
+    Parameters
+    ----------
+    root_dir: Path
+        Path of trimmed crops with various speckle variants and recording times.
+    speckle: String
+        Set the desired speckle variant (options available in geocropper.stack_trimmed_images)
+    position: String
+        Set the position of the image in latitude and longitude format as a string (e.g. "-68.148781_44.77383")
+    """
+
+    image_path_list = []
+    for folder in root_dir.glob(f"*{speckle}*"):
+        if folder.is_dir() and folder.name.split("_")[0] != "stacked":
+            for crop in folder.glob(f"*{position}*"):
+                if crop.is_dir():
+                    image_path = crop / "sensordata" / "s1_cropped.tif"
+                    image_path_list.append(image_path)
+
+    return image_path_list
+
+
+def mkdir_for_stacked_image(output_dir, speckle, position):
+    """Makes a directory in the output_dir for the stacked image named by the lat_lon position and returns the 
+    path to the created directory.
+
+    Parameters
+    ----------
+    output_dir: Path
+        Path where the stacked image shall be stored
+    speckle: String
+        Set the desired speckle variant (options available in geocropper.stack_trimmed_images)
+    position: String
+        Set the position of the image in latitude and longitude format as a string (e.g. "-68.148781_44.77383")
+    """
+    
+    stacked_image_path = output_dir / ("stacked_images_" + speckle) / position
+
+    try:
+        stacked_image_path.mkdir(exist_ok=True, parents=True)
+    except OSError as error:
+        print (f"Creation of the directory {stacked_image_path} failed")
+        print(error)
+        sys.exit()
+    else:
+        return stacked_image_path
+
+
+def stack_trimmed_images(image_path_list, output_dir, speckle, position):
+    """Stacks trimmed images from provided image_path_list with rasterio in order to preserve the georeferencing
+    and writes both bands to tif files ("s1_stacked_VV.tif", "s1_stacked_VH.tif").
+
+    Parameters
+    ----------
+    image_path_list: List
+        List containing paths of images of the same position with different capture dates.
+    output_dir: Path
+        Path where the stacked image shall be stored
+    speckle: String
+        Set the desired speckle variant (options available in geocropper.stack_trimmed_images)
+    position: String
+        Set the position of the image in latitude and longitude format as a string (e.g. "-68.148781_44.77383")
+    """
+
+    rasterio_image_list = []
+    for image_path in image_path_list:
+        rasterio_image_list.append(rasterio.open(image_path))
+
+    try:
+        profile = rasterio_image_list[0].profile
+        profile.update({"count":len(rasterio_image_list)})
+
+        stacked_image_path = mkdir_for_stacked_image(output_dir, speckle, position)
+
+        for band, tif_file in enumerate(["s1_stacked_VV.tif", "s1_stacked_VH.tif"], start=1):
+            with rasterio.open((stacked_image_path / tif_file), "w", **profile) as dest:
+                for i, image in enumerate(rasterio_image_list, start=1):
+                    dest.write(image.read(band), i)
+    
+    except IndexError as error:
+        print (f"No images for stacking were found.")
+        print(error)
+        sys.exit()

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -1908,7 +1908,7 @@ def stack_trimmed_images(image_path_list, output_dir, position, postfix="", tif_
     postfix: String, optional
         Set desired postfix for selecting specific folders containing a certain string 
         (by default is empty "" and therefore selects every folder in source_dir)
-    tif_band_names: String, optional
+    tif_band_name_list: String, optional
         Set names for the bands of the tif tiles (by default the bands are called ["s1_stacked_VV.tif", "s1_stacked_VH.tif"])
     """
 


### PR DESCRIPTION
This pull request adds the functionality to stack trimmed images of the same position with different capture dates.

The following functions were added:
geocropper.stack_trimmed_images(root_dir, speckle, output_dir=None)
utils.get_unique_lat_lon(root_dir, speckle)
utils.get_image_path_list(root_dir, speckle, position)
utils.mkdir_for_stacked_image(output_dir, speckle, position)
utils.stack_trimmed_images(image_path_list, output_dir, speckle, position)