### PR TITLE
PCA

### DIFF
--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -1150,7 +1150,7 @@ def compare_csv_locations(csv_dir, reference_csv_path=None, result_csv_path=None
                     spamwriter.writerow(numpy.append(numpy.array([str(lon), str(lat), str(s)]), counts))
 
 
-def create_dimensionality_reduced_images(source_dir, target_dir=None, dim_reduction_method="pca"):
+def create_dimensionality_reduced_images(source_dir, target_dir=None, dim_reduction_method="max_values"):
     """Reduces the dimensions of standardized and stacked images by extracting the most relevant information of each layer.
 
     The source_dir points to the standardized_stacked_images. These images have multiple layers x (e.g. (x, 400, 400))
@@ -1164,9 +1164,9 @@ def create_dimensionality_reduced_images(source_dir, target_dir=None, dim_reduct
     target_dir: String, optional
         Default is source_dir with prefix "dim_reduced_"
     dim_reduction_method: String, optional
-        Set the method for dimensionality reduction (default is "pca")
-        "pca" = Principal Component Analysis, simplify data with a small amount of linear components
+        Set the method for dimensionality reduction (default is "max_values")
         "max_values" = The maximum value of each pixel from all layers is selected
+        "pca" = Principal Component Analysis, simplify data with a small amount of linear components
     """
 
     source_dir = pathlib.Path(source_dir)

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -999,12 +999,12 @@ def stack_trimmed_images(source_dir, postfix="", target_dir=None):
     
     Parameters
     ----------
-    source_dir: Path
+    source_dir: String
         Path of trimmed crops of various recording times which shall be stacked
     postfix: String, optional
         Set desired postfix for selecting specific folders containing a certain string 
         (default is empty "" and therefore selects every folder in source_dir).
-    target_dir: Path, optional
+    target_dir: String, optional
         Path where the stacked image shall be stored (by default is equal to root_dir)
     """
 
@@ -1026,9 +1026,9 @@ def standardize_stacked_images(source_dir, target_dir=None, standardization_proc
     
     Parameters
     ----------
-    source_dir: Path
+    source_dir: String
         Path of stacked images which shall be standardized
-    target_dir: Path, optional
+    target_dir: String, optional
         default is source_dir with prefix "standardized_"
     standardization_procedure: String, optional
         Set the standardization precedure (default is "layerwise")
@@ -1148,3 +1148,34 @@ def compare_csv_locations(csv_dir, reference_csv_path=None, result_csv_path=None
                     s = sums[i]
                     counts = numpy.array(lat_lon_counter[i], str)
                     spamwriter.writerow(numpy.append(numpy.array([str(lon), str(lat), str(s)]), counts))
+
+
+def create_dimensionality_reduced_images(source_dir, target_dir=None):
+    """Reduces the dimensions of stacked images by extracting the most relevant information of each layer.
+
+    The source_dir points to the standardized_stacked_images. These images have multiple layers x (e.g. (x, 400, 400))
+    which are reduced to one final layer (e.g. (400, 400)). This dimensionality reduced image contains information
+    based on all provided layers x.
+
+    Parameters
+    ----------
+    source_dir: String
+        Path of standardized_stacked_images which dimension shall be reduced
+    target_dir: String, optional
+        Default is source_dir with prefix "dim_reduced_"
+    """
+
+    source_dir = pathlib.Path(source_dir)
+    if target_dir == None:
+        target_dir = source_dir.parent / ("dim_reduced_" + source_dir.name)
+    else:
+        target_dir = pathlib.Path(target_dir)
+    
+    for image_dir in tqdm(source_dir.glob("*"), desc="Reducing dimensionality of images: "):
+        if image_dir.is_dir() and not image_dir.name.startswith("0_"):
+            crop = image_dir.name
+            # every standardized_stacked_image folder for each location should contain either "s1_standardized_VV.tif" or
+            # "s1_standardized_VH.tif" or both. Therefore the dimension of both images will be reduced seperately.
+            image_names = ["s1_standardized_VV.tif", "s1_standardized_VH.tif"]
+            for image_name in image_names:
+                utils.reduce_image_dimensionality(image_dir, image_name, target_dir, crop)

--- a/geocropper/geocropper.py
+++ b/geocropper/geocropper.py
@@ -1150,11 +1150,11 @@ def compare_csv_locations(csv_dir, reference_csv_path=None, result_csv_path=None
                     spamwriter.writerow(numpy.append(numpy.array([str(lon), str(lat), str(s)]), counts))
 
 
-def create_dimensionality_reduced_images(source_dir, target_dir=None):
-    """Reduces the dimensions of stacked images by extracting the most relevant information of each layer.
+def create_dimensionality_reduced_images(source_dir, target_dir=None, dim_reduction_method="pca"):
+    """Reduces the dimensions of standardized and stacked images by extracting the most relevant information of each layer.
 
     The source_dir points to the standardized_stacked_images. These images have multiple layers x (e.g. (x, 400, 400))
-    which are reduced to one final layer (e.g. (400, 400)). This dimensionality reduced image contains information
+    which are reduced to one final layer (e.g. (1, 400, 400)). This dimensionality reduced image contains information
     based on all provided layers x.
 
     Parameters
@@ -1163,6 +1163,10 @@ def create_dimensionality_reduced_images(source_dir, target_dir=None):
         Path of standardized_stacked_images which dimension shall be reduced
     target_dir: String, optional
         Default is source_dir with prefix "dim_reduced_"
+    dim_reduction_method: String, optional
+        Set the method for dimensionality reduction (default is "pca")
+        "pca" = Principal Component Analysis, simplify data with a small amount of linear components
+        "max_values" = The maximum value of each pixel from all layers is selected
     """
 
     source_dir = pathlib.Path(source_dir)
@@ -1178,4 +1182,4 @@ def create_dimensionality_reduced_images(source_dir, target_dir=None):
             # "s1_standardized_VH.tif" or both. Therefore the dimension of both images will be reduced seperately.
             image_names = ["s1_standardized_VV.tif", "s1_standardized_VH.tif"]
             for image_name in image_names:
-                utils.reduce_image_dimensionality(image_dir, image_name, target_dir, crop)
+                utils.reduce_image_dimensionality(image_dir, image_name, target_dir, crop, dim_reduction_method)

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -2205,4 +2205,4 @@ def reduce_image_dimensionality(image_dir, image_name, target_dir, crop, dim_red
         
         else:
 
-            print("Choose a correct dime_reduction_method ('pca' or 'max_values')!")
+            print("Please, choose a valid dim_reduction_method ('pca' or 'max_values')!")

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -28,8 +28,7 @@ from sklearn import preprocessing
 try:
     import otbApplication
 except ImportError:
-    print("otbApplication is not installed!")
-    print("PCA mode in function create_dimensionality_reduced_images is disabled.")
+    pass
 
 
 import geocropper.config as config
@@ -2145,9 +2144,10 @@ def reduce_image_dimensionality(image_dir, image_name, target_dir, crop, dim_red
     crop: String
         Location of the crop in latitude and longitude format as a string (e.g. "-68.148781_44.77383")
     dim_reduction_method: String, optional
-        Set the method for dimension reduction (default is "pca")
-        "pca" = Principal Component Analysis, simplify data with a small amount of linear components
+        Set the method for dimension reduction (default is "max_values")
         "max_values" = The maximum value of each pixel from all layers is selected
+        "pca" = Principal Component Analysis, simplify data with a small amount of linear components. 
+            If pca is chosen as dim_reduction_method "otbApplication" has to be installed => check import otbApplication info.
     """
 
     output_dir = target_dir / crop
@@ -2168,19 +2168,7 @@ def reduce_image_dimensionality(image_dir, image_name, target_dir, crop, dim_red
 
     else:
 
-        if dim_reduction_method == "pca":
-
-            app = otbApplication.Registry.CreateApplication("DimensionalityReduction")
-
-            app.SetParameterString("in", str(image_dir / image_name))
-            app.SetParameterString("out", str(output_dir / new_image_name))
-            app.SetParameterString("method", dim_reduction_method)
-            # nbcomp = Number of components, therefore it will be reduced to one component (from (x, 400, 400) to (1, 400, 400))
-            app.SetParameterInt("nbcomp", 1)
-
-            app.ExecuteAndWriteOutput()
-
-        elif dim_reduction_method == "max_values":
+        if dim_reduction_method == "max_values":
 
             image = rasterio.open((image_dir / image_name))
             profile = image.profile
@@ -2196,7 +2184,25 @@ def reduce_image_dimensionality(image_dir, image_name, target_dir, crop, dim_red
 
             with rasterio.open((output_dir / new_image_name), "w", **profile) as dest:
                 dest.write(max_values_image_array)
+
+        elif dim_reduction_method == "pca":
+
+            # check if otbApplication is installed since this is required for the PCA
+            if "otbApplication" not in sys.modules:
+                print("'pca' was chosen as dimensionality reduction method but otbApplication is not installed!")
+                print("Please, install otbApplication on your machine or use 'max_values' as dimensionality reduction method!")
+                return
+
+            app = otbApplication.Registry.CreateApplication("DimensionalityReduction")
+
+            app.SetParameterString("in", str(image_dir / image_name))
+            app.SetParameterString("out", str(output_dir / new_image_name))
+            app.SetParameterString("method", dim_reduction_method)
+            # nbcomp = Number of components, therefore it will be reduced to one component (from (x, 400, 400) to (1, 400, 400))
+            app.SetParameterInt("nbcomp", 1)
+
+            app.ExecuteAndWriteOutput()
         
         else:
 
-            print("Choose a correct dim_reduction_method ('pca' or 'max_values')")
+            print("Choose a correct dime_reduction_method ('pca' or 'max_values')!")

--- a/geocropper/utils.py
+++ b/geocropper/utils.py
@@ -25,7 +25,12 @@ from datetime import datetime
 from distutils.dir_util import copy_tree
 from skimage import transform
 from sklearn import preprocessing
-import otbApplication
+try:
+    import otbApplication
+except ImportError:
+    print("otbApplication is not installed!")
+    print("PCA mode in function create_dimensionality_reduced_images is disabled.")
+
 
 import geocropper.config as config
 import geocropper.download as download


### PR DESCRIPTION
Reduces the dimension of standardized and stacked images by extracting the most relevant information of each layer. The method PCA requires `otbApplication` which unfortunately has to be installed manually and cannot be directly installed with anaconda.